### PR TITLE
change gnome-terminal to correct wmclass

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,10 +38,10 @@ This line cycles any firefox window (matched by "firefox" in the window title) O
 <Super>f,firefox,,
 ```
 
-This line cycles any open gnome-terminal (matched by `wm_class = Gnome-terminal`) OR if not found, launches a new one.
+This line cycles any open gnome-terminal (matched by `wm_class = gnome-terminal-server`) OR if not found, launches a new one.
 
 ```
-<Super>r,gnome-terminal,Gnome-terminal,
+<Super>r,gnome-terminal,gnome-terminal-server,
 ```
 
 You may use **regular expressions** in title or wm_class. Just put the expression between slashes.   

--- a/shortcuts.default
+++ b/shortcuts.default
@@ -16,8 +16,8 @@
 #
 # This line cycles any firefox window (matched by "firefox" in the window title) OR if not found, launches new firefox instance.
 <Super>f,firefox,,
-# This line cycles any open gnome-terminal (matched by wm_class = Gnome-terminal) OR if not found, launches new one.
-<Super>r,gnome-terminal,Gnome-terminal,
+# This line cycles any open gnome-terminal (matched by wm_class = gnome-terminal-server) OR if not found, launches new one.
+<Super>r,gnome-terminal,gnome-terminal-server,
 
 
 # You may use regular expression in title or wm_class.


### PR DESCRIPTION
Hi, I found that this worked, and the previous version didn't — it would keep creating new instances. I also that found gnome-terminal with a lower-case 'g' worked too.
Also, that new name came straight from Alt-F2 -> lg -> Windows -> wmclass.