### PR TITLE
run-AND-raise

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -191,7 +191,11 @@ const Controller = new Lang.Class({ // based on https://superuser.com/questions/
                 if (line[0] == "#" || line.trim() == "") {
                     continue;
                 }
-                let s = line.split(",")
+                var splitter = ",";
+                if (line.indexOf("|") > -1) {
+                    splitter = "|";
+                }
+                let s = line.split(splitter);
                 if (s.length > 2) { // shortcut, launch, wm_class, title
                     this.keyManager.listenFor(s[0].trim(), this.jumpapp(s))
                 } else { // shortcut, command

--- a/extension.js
+++ b/extension.js
@@ -84,9 +84,14 @@ const Controller = new Lang.Class({ // based on https://superuser.com/questions/
 
         return function () {
             var launch = shortcut[1].trim();
-            var wm_class, wmFn, title, titleFn;
+            var wm_class, wmFn, title, titleFn, runAndRaise;
             [wm_class, wmFn] = _prepare(shortcut[2].trim());
             [title, titleFn] = _prepare(shortcut[3].trim());
+
+            runAndRaise = false;
+            if (shortcut.length > 4 && shortcut[4] === "&") {
+                runAndRaise = true;
+            }
 
             let seen = 0;
 
@@ -152,6 +157,9 @@ const Controller = new Lang.Class({ // based on https://superuser.com/questions/
                             focusWindow(lastWindow);
                         }
                     }
+                }
+                if (runAndRaise) {
+                    imports.misc.util.spawnCommandLine(launch);
                 }
             } else {
                 imports.misc.util.spawnCommandLine(launch);


### PR DESCRIPTION
Add ,& to the end of the shortcut definition to both raise the window and run the launch script.

For example, I use it to control which tmux session to switch to.
