### PR TITLE
gnome-shell-3.38.4: fix

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,10 +4,10 @@ const Shell = imports.gi.Shell;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const {spawnCommandLine, spawn} = imports.misc.util;
 const Convenience = Me.imports.convenience;
-const Gdk = imports.gi.Gdk
-const Keymap = Gdk.Keymap.get_for_display(Gdk.Display.get_default())
+const Gdk = imports.gi.Gdk;
+const Keymap = Gdk.Keymap.get_for_display(Gdk.Display.get_default());
 
-let app, conf_path, default_conf_path, settings
+let app, conf_path, default_conf_path, settings;
 
 function log() {
     global.log.apply(null, arguments);

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "shell-version": [
     "3.32",
     "3.32.1",
-    "3.38.1"
+    "3.38.1",
+    "3.38.4"
   ],   
   "url": "https://github.com/CZ-NIC/run-or-raise",
   "uuid": "run-or-raise@edvard.cz", 


### PR DESCRIPTION
Without the changes gnome-shell-3.38.4 raises the following error:
```
JS ERROR: Extension run-or-raise@edvard.cz: Error: Argument display may not be null
                                                   @/home/johannes/.local/share/gnome-shell/extensions/run-or-raise@edvard.cz/extension.js:8:27
                                                   _callExtensionInit@resource:///org/gnome/shell/ui/extensionSystem.js:422:13
                                                   loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:347:27
                                                   _loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:588:18
                                                   collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:28
                                                   _loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:567:19
                                                   _enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:597:18
                                                   _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:628:18
                                                   init@resource:///org/gnome/shell/ui/extensionSystem.js:56:14
                                                   _initializeUI@resource:///org/gnome/shell/ui/main.js:269:22
                                                   start@resource:///org/gnome/shell/ui/main.js:159:5
                                                   @<main>:1:47
```