### PR TITLE
Add support for .desktop files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 13
+- added shell version 41 support
+
 ## 12 (2021-04-30, Gnome 40)
 - added shell version 40 support #33 #34
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 13
 - added shell version 41 support
+- added support for starting applications from .desktop files
 
 ## 12 (2021-04-30, Gnome 40)
 - added shell version 40 support #33 #34

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ When you trigger a shortcut it lets you cycle amongst open instances of the appl
 `shortcut[:mode],[command],[wm_class],[title]`
 
 * `wm_class`, `title` and `mode` arguments are optional and case-sensitive
+* `command` can be either a commandline to launch, or the name of an application's .desktop file.
+If `command` is a commandline, this extension will spawn a new process using that commandline. If `command` points to a .desktop
+file, this extension will activate the application from that .desktop file.
 * if neither `wm_class` nor `title`  is set, lower-cased `command` is compared with lower-cased windows' wm_classes and titles
 * multiple modes can be used together
 * multiple actions may be registered to the same shortcut
@@ -122,6 +125,12 @@ This line cycles any firefox window (matched by "firefox" in the window title) O
 
 ```
 <Super>f,firefox,,
+```
+
+This line starts gnome-terminal using it's .desktop file:
+
+```
+<Super>f,org.gnome.Terminal.desktop,,
 ```
 
 This line cycles any open gnome-terminal OR if not found, launches a new one.

--- a/extension.js
+++ b/extension.js
@@ -431,6 +431,10 @@ class Action {
         if (this.mode.get(Mode.VERBOSE)) {
             this.debug("running:", this.command)
         }
+        const app = Shell.AppSystem.get_default().lookup_app(this.command);
+        if (app !== null) {
+            return app.activate();
+        }
         return spawnCommandLine(this.command);
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -7,8 +7,9 @@
     "3.36",
     "3.38.1",
     "40",
-    "40.1"
-  ],   
+    "40.1",
+    "41"
+  ],
   "url": "https://github.com/CZ-NIC/run-or-raise",
   "uuid": "run-or-raise@edvard.cz", 
   "settings-schema":  "org.gnome.shell.extensions.run-or-raise",


### PR DESCRIPTION
If the given command matches a known .desktop file, have Gnome start the associated application instead using AppSystem instead of passing the command to spawnCommandLine()