### PR TITLE
mark compatible with GNOME 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
     "3.36",
     "3.38.1",
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/CZ-NIC/run-or-raise",
   "uuid": "run-or-raise@edvard.cz", 


### PR DESCRIPTION
I made this change and tested it on GNOME 42 on NixOS master and it
worked for me.