### PR TITLE
GNOME 44 support and change of the "hello world" shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Since it is very convenient to use a single file for all of your shortcuts (back
 
 ```
 # this line will launch the notify-send command.
-<Super>h,notify-send Hello world
+<Control><Super>h,notify-send Hello world
 
 # this line WILL raise a Firefox window or launches a command (note a trailing comma)
 <Super>f,firefox,

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Since it is very convenient to use a single file for all of your shortcuts (back
 
 ```
 # this line will launch the notify-send command.
-<Control><Super>h,notify-send Hello world
+<Super>y,notify-send Hello world
 
 # this line WILL raise a Firefox window or launches a command (note a trailing comma)
 <Super>f,firefox,

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/CZ-NIC/run-or-raise",
   "uuid": "run-or-raise@edvard.cz",

--- a/shortcuts.default
+++ b/shortcuts.default
@@ -40,7 +40,7 @@
 # =============
 #
 # This line will launch the `notify-send` command.
-<Super>h,notify-send Hello world
+<Control><Super>h,notify-send Hello world
 
 # This layered shortcut will output the text only when you write `hello` after hitting <Super>e.
 <Super>e h e l l o,notify-send Layered hello

--- a/shortcuts.default
+++ b/shortcuts.default
@@ -40,7 +40,7 @@
 # =============
 #
 # This line will launch the `notify-send` command.
-<Control><Super>h,notify-send Hello world
+<Super>y,notify-send Hello world
 
 # This layered shortcut will output the text only when you write `hello` after hitting <Super>e.
 <Super>e h e l l o,notify-send Layered hello


### PR DESCRIPTION
Super+h is already binded to the /org/gnome/desktop/wm/keybindings/minimize by default. So extension can't grab it.