### PR TITLE
Gnome 45 support

### DIFF
--- a/convenience.js
+++ b/convenience.js
@@ -25,17 +25,12 @@
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 // const GIRepository = imports.gi.GIRepository;
-import GIRepository from 'gi://GIRepository?version=4.0';
+import GIRepository from 'gi://GIRepository';
 GIRepository.Repository.prepend_search_path("/usr/lib/gnome-shell");
 GIRepository.Repository.prepend_library_path("/usr/lib/gnome-shell");
-// const Gio = imports.gi.Gio;
-// const GLib = imports.gi.GLib;
 import GLib from 'gi://GLib';
 
-// const ExtensionUtils = imports.misc.extensionUtils;
-
-function getSchemaData(schema) {
-    const Settings = this.getSettings()
+export function getSchemaData(Settings) {    
     const schemaObj = Settings["settings_schema"]
     const basicTypes = ["b", "y", "n", "q", "i", "u", "x", "t", "h", "d", "s", "o", "g", "?"].map(function(type){return {type: type, vt :  new GLib.VariantType(type)}});
     const allKeys = schemaObj.list_keys().map(function(keyName) {

--- a/extension.js
+++ b/extension.js
@@ -14,7 +14,7 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
  * @typedef {import('./lib/action.js')}
 */
 //const Action = Me.imports.lib.action.Action
-import * as Action from './lib/action.js';
+import {parseLine} from './lib/action.js';
 /**
  * @typedef {import('./lib/accelerator.js')}
 */
@@ -149,7 +149,7 @@ class App {
                 if (line[0] === "#" || line.trim() === "") {  // skip empty lines and comments
                     continue
                 }
-                const action = Action.parseLine(line, this)
+                const action = parseLine(line, this)
                 this.accelerators.get(action.shortcut).push(action)
             } catch (e) {
                 this.display(`Cannot parse line: ${line}.${e}`)

--- a/extension.js
+++ b/extension.js
@@ -19,12 +19,12 @@ import {parseLine} from './lib/action.js';
  * @typedef {import('./lib/accelerator.js')}
 */
 //const Accelerator = Me.imports.lib.accelerator.Accelerator
-import * as Accelerator from './lib/accelerator.js';
+import {Accelerator} from './lib/accelerator.js';
 /**
  * @typedef {import('./lib/mode.js').Mode} Mode
 */
 // const Mode = Me.imports.lib.mode.Mode
-import * as Mode from './lib/mode.js';
+import {Mode} from './lib/mode.js';
 /**
  * @typedef {import('./lib/static.js')}
 */
@@ -36,10 +36,6 @@ import {arraysEqual, DefaultMap} from './lib/static.js';
  * @typedef {boolean[]} State Array of true/false
  */
 let conf_path, default_conf_path
-/**
- * @type {App}
- */
-let app
 
 
 /**
@@ -341,12 +337,12 @@ export default class RunOrRaiseExtension extends Extension {
     enable() {
         const seat = Clutter.get_default_backend().get_default_seat()
         const keymap = seat.get_keymap()
-        app = new App(this.getSettings(), seat, keymap)
-        app.enable()
+        this.app = new App(this.getSettings(), seat, keymap)
+        this.app.enable()
     }
 
     disable() {
-        app.disable()
-        app = null
+        this.app.disable()
+        this.app = null
     }
 }

--- a/lib/accelerator.js
+++ b/lib/accelerator.js
@@ -12,7 +12,7 @@ import {arraysEqual} from './static.js';
  *  @typedef {Action[]} Accelerator Actions in the array have the same shortcut accelerator.
  *  XX do not know how to document the values of a class extending array properly
  */
-var Accelerator = class extends Array {
+export class Accelerator extends Array {
 
     /**
      *

--- a/lib/action.js
+++ b/lib/action.js
@@ -6,7 +6,7 @@ import { spawnCommandLine } from 'resource:///org/gnome/shell/misc/util.js';
 // const Me = ExtensionUtils.getCurrentExtension()
 
 // const Mode = Me.imports.lib.mode.Mode
-import * as Mode from './mode.js';
+import {Mode} from './mode.js';
 
 class Action {
 

--- a/lib/action.js
+++ b/lib/action.js
@@ -8,7 +8,7 @@ import { spawnCommandLine } from 'resource:///org/gnome/shell/misc/util.js';
 // const Mode = Me.imports.lib.mode.Mode
 import * as Mode from './mode.js';
 
-var Action = class {
+class Action {
 
     /**
      * Single shortcut binding representation
@@ -284,28 +284,29 @@ var Action = class {
         }
         return true
     }
+   
+}
 
-    static parseLine(line, app) {
-        // Optional argument quoting in the format: `shortcut[:mode][:mode],[command],[wm_class],[title]`
-        // ', b, c, "d, e,\" " f", g, h' -> ["", "b", "c", "d, e,\" \" f", "g", "h"]
-        const args = line.split(/,(?![^"]*"(?:(?:[^"]*"){2})*[^"]*$)/)
-            .map(s => s.trim())
-            .map(s => (s[0] === '"' && s.slice(-1) === '"') ? s.slice(1, -1).trim() : s) // remove quotes
-        const [shortcut_layer_mode, command, wm_class, title] = args
+export function  parseLine(line, app) {
+    // Optional argument quoting in the format: `shortcut[:mode][:mode],[command],[wm_class],[title]`
+    // ', b, c, "d, e,\" " f", g, h' -> ["", "b", "c", "d, e,\" \" f", "g", "h"]
+    const args = line.split(/,(?![^"]*"(?:(?:[^"]*"){2})*[^"]*$)/)
+        .map(s => s.trim())
+        .map(s => (s[0] === '"' && s.slice(-1) === '"') ? s.slice(1, -1).trim() : s) // remove quotes
+    const [shortcut_layer_mode, command, wm_class, title] = args
 
-        // Split shortcut[:mode][:mode] -> shortcut, mode
-        const [shortcut_layer, ...modes] = shortcut_layer_mode.split(":")
-        const [shortcut_bare, ...layers] = shortcut_layer.split(" ")
-        // Store to "shortcut:cmd:launch(2)" → new Mode([["cmd", true], ["launch": 2]])
-        const mode = new Mode(modes
-            .map(m => m.match(/(?<key>[^(]*)(\((?<arg>.*?)\))?/)) // "launch" -> key=launch, arg=undefined
-            .filter(m => m) // "launch" must be a valid mode string
-            .map(m => [m.groups.key, m.groups.arg || true])  // ["launch", true]
-            , app.settings
-        )
-        if (args.length <= 2) { // Run only mode, we never try to raise a window
-            mode.add(Mode.RUN_ONLY, true)
-        }
-        return new Action(app, shortcut_bare, layers, mode, command, wm_class, title)
+    // Split shortcut[:mode][:mode] -> shortcut, mode
+    const [shortcut_layer, ...modes] = shortcut_layer_mode.split(":")
+    const [shortcut_bare, ...layers] = shortcut_layer.split(" ")
+    // Store to "shortcut:cmd:launch(2)" → new Mode([["cmd", true], ["launch": 2]])
+    const mode = new Mode(modes
+        .map(m => m.match(/(?<key>[^(]*)(\((?<arg>.*?)\))?/)) // "launch" -> key=launch, arg=undefined
+        .filter(m => m) // "launch" must be a valid mode string
+        .map(m => [m.groups.key, m.groups.arg || true])  // ["launch", true]
+        , app.settings
+    )
+    if (args.length <= 2) { // Run only mode, we never try to raise a window
+        mode.add(Mode.RUN_ONLY, true)
     }
+    return new Action(app, shortcut_bare, layers, mode, command, wm_class, title)
 }

--- a/lib/mode.js
+++ b/lib/mode.js
@@ -1,7 +1,7 @@
 /**
  * Allow user to cast a specific instruction
  */
-var Mode = class Mode {
+export class Mode {
 
     /**
      * @param values Ex: [["cmd", true], ["launch": 2]]

--- a/lib/static.js
+++ b/lib/static.js
@@ -1,7 +1,7 @@
 /**
  * Helper class (simulating Python collections.defaultdict)
  */
-var DefaultMap = class DefaultMap extends Map {
+export class DefaultMap extends Map {
     get(key) {
         if (!this.has(key)) {
             super.set(key, this.default(key))
@@ -15,7 +15,7 @@ var DefaultMap = class DefaultMap extends Map {
     }
 }
 
-var arraysEqual = function(arr1, arr2) {
+export const arraysEqual = function(arr1, arr2) {
     if (arr1.length != arr2.length) {
         return false
     }

--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,7 @@
   "name": "Run or raise",
   "settings-schema": "org.gnome.shell.extensions.run-or-raise",
   "shell-version": [
-    "42",
-    "43",
-    "44"
+    "45"
   ],
   "url": "https://github.com/CZ-NIC/run-or-raise",
   "uuid": "run-or-raise@edvard.cz",

--- a/prefs.js
+++ b/prefs.js
@@ -6,16 +6,26 @@ import Gtk from 'gi://Gtk?version=4.0';
 import GLib from 'gi://GLib';
 // const Convenience = Me.imports.convenience;
 import * as Convenience from './convenience.js';
-
-
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import Adw from 'gi://Adw';
 
 
-export default class ExamplePreferences extends ExtensionPreferences {
+export default class RunOrRaisePreferences extends ExtensionPreferences {
 
+    fillPreferencesWindow(window) {
+        window._settings = this.getSettings();
 
-    getPreferencesWidget() {
-        let convData = Convenience.getSchemaData();
+        const page = new Adw.PreferencesPage();
+
+        const group = new Adw.PreferencesGroup();
+        group.add(this.getWidget())
+        page.add(group);
+
+        window.add(page);
+    }
+
+    getWidget() {
+        let convData = Convenience.getSchemaData(this.getSettings());
         let vbox = new Gtk.Box({
             orientation: Gtk.Orientation.VERTICAL,
             margin_top: 15,
@@ -25,7 +35,7 @@ export default class ExamplePreferences extends ExtensionPreferences {
         editorButton.connect("clicked", function() {
             GLib.spawn_command_line_sync("xdg-open .config/run-or-raise/shortcuts.conf");
         });
-        let settingLabel = new Gtk.Label({label: "Edit the file to add your shortcuts, then reload this extension (no logout required)"});
+        let settingLabel = new Gtk.Label({label: "Edit the file to add your shortcuts, then reload this extension (no logout required)", wrap: true});
 
         vbox.append(settingLabel);
         vbox.append(editorButton);
@@ -37,7 +47,7 @@ export default class ExamplePreferences extends ExtensionPreferences {
 }
 
 function booleanBox(data, settings) {
-        const vbox = new Gtk.Box({
+        const hbox = new Gtk.Box({
             orientation: Gtk.Orientation.HORIZONTAL,
             margin_top: 15,
             spacing: 10
@@ -48,7 +58,7 @@ function booleanBox(data, settings) {
         switcher.connect('notify::active', function(o) {
             settings.set_boolean(data.name, o.active)
         })
-        vbox.append(switcher)
-        vbox.append(label)
-        return vbox
+        hbox.append(switcher)
+        hbox.append(label)
+        return hbox
 }

--- a/prefs.js
+++ b/prefs.js
@@ -7,6 +7,7 @@ import GLib from 'gi://GLib';
 // const Convenience = Me.imports.convenience;
 import * as Convenience from './convenience.js';
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import Gio from 'gi://Gio';
 import Adw from 'gi://Adw';
 
 
@@ -17,48 +18,57 @@ export default class RunOrRaisePreferences extends ExtensionPreferences {
 
         const page = new Adw.PreferencesPage();
 
-        const group = new Adw.PreferencesGroup();
-        group.add(this.getWidget())
-        page.add(group);
+        page.add(this.getShortcutConfig());
+        page.add(this.getBehaviourConfig());
 
         window.add(page);
     }
 
-    getWidget() {
-        let convData = Convenience.getSchemaData(this.getSettings());
-        let vbox = new Gtk.Box({
-            orientation: Gtk.Orientation.VERTICAL,
-            margin_top: 15,
-            spacing: 10
+    getShortcutConfig() {
+        const group = new Adw.PreferencesGroup({
+            title: "Shortcuts",
         });
-        let editorButton = new Gtk.Button({label: "Open shortcuts.conf file"});
+
+        const row = new Adw.ActionRow({
+            title: 'Open shortcuts.conf file',
+            subtitle: 'Edit the file to add your shortcuts, then reload this extension (no logout required)',
+        });
+        let editorButton = new Gtk.Button({
+            iconName: "document-open-symbolic", 
+            valign: Gtk.Align.CENTER,
+            halign: Gtk.Align.CENTER
+        });
         editorButton.connect("clicked", function() {
             GLib.spawn_command_line_sync("xdg-open .config/run-or-raise/shortcuts.conf");
         });
-        let settingLabel = new Gtk.Label({label: "Edit the file to add your shortcuts, then reload this extension (no logout required)", wrap: true});
+        row.add_suffix(editorButton);
+        row.set_activatable_widget(editorButton);
 
-        vbox.append(settingLabel);
-        vbox.append(editorButton);
-        convData.basicSchema.forEach(function(data) {
-            vbox.append(booleanBox(data, convData.settings));
+        group.add(row);
+        
+        return group;
+    }
+
+    getBehaviourConfig() {
+        const group = new Adw.PreferencesGroup({
+            title: "Behaviour",
+            description: "Configure various behaviours of run or raise"
         });
-        return vbox;
+        let convData = Convenience.getSchemaData(this.getSettings());
+        
+        convData.basicSchema.forEach(function(data) {
+            group.add(booleanBox(data, convData.settings));
+        });
+        
+        return group;
     }
 }
 
 function booleanBox(data, settings) {
-        const hbox = new Gtk.Box({
-            orientation: Gtk.Orientation.HORIZONTAL,
-            margin_top: 15,
-            spacing: 10
-        })
-        const switcher = new Gtk.Switch({active: data.value})
-        const text = data.summary + (data.description? ": " + data.description : "")
-        const label = new Gtk.Label({label: text})
-        switcher.connect('notify::active', function(o) {
-            settings.set_boolean(data.name, o.active)
-        })
-        hbox.append(switcher)
-        hbox.append(label)
-        return hbox
+        const row = new Adw.SwitchRow({
+            title: data.summary,
+            subtitle: data.description ? data.description : "",
+        });
+        settings.bind(data.name, row, 'active', Gio.SettingsBindFlags.DEFAULT);
+        return row
 }


### PR DESCRIPTION
This should fix https://github.com/CZ-NIC/run-or-raise/issues/60

- Use `const` instead of `var` at some places.
- Move app into extension class as a member variable.
- Export `parseLine` to create Action instead of directly export Action.
- Refactor the preferences dialog. Gnome 45 did not display all the text as the dialog was too wide.