### PR TITLE
Fix #68 - Mention out-of-the-box alternative (ab)using GNOME Shell "switch-to-application-N" dconf entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,26 @@ https://extensions.gnome.org/extension/1336/run-or-raise/
 
 # About project
 
-I assume the run-or-raise style as the most efficient way of handling windows. No more searching for your favourite program in a long menu, no more clicking on the icons. If the program already runs it will get the focus, else we launch it. Several years ago, OS creators finally realized that efficiency and let the users run-or-raise programs on the taskbar or dock by <kbd>Super+number</kbd> shortcuts. But what if you use more programs than nine? What if you do not want the unnecessary taskbar to occupy the precious place on the screen?
-With the emergence of Wayland over X.org in Ubuntu 17.10, we can't reliably use good old [`xbindkeys`](https://wiki.archlinux.org/index.php/Xbindkeys) and [`jumpapp`](https://github.com/mkropat/jumpapp) to master shortcuts. Here is a gnome-shell extension that let you migrate your favourite shortcuts to the `shortcuts.conf` file.
+I assume the run-or-raise style as the most efficient way of handling windows. No more searching for your favourite program in a long menu, no more clicking on the icons. If the program already runs it will get the focus, else we launch it.
+
+Several years ago, OS creators finally realized that efficiency and let the users run-or-raise programs on the taskbar or dock by <kbd>Super+number</kbd> shortcuts. But what if you use more programs than nine? What if you do not want the unnecessary taskbar to occupy the precious place on the screen?
+
+With the emergence of Wayland over X.org, we can't reliably use good old [`xbindkeys`](https://wiki.archlinux.org/index.php/Xbindkeys) and [`jumpapp`](https://github.com/mkropat/jumpapp) to master shortcuts. Here is a gnome-shell extension that let you migrate your favourite shortcuts to the `shortcuts.conf` file.
+
+## Barebones “GNOME Shell native” alternative
+
+Note that GNOME Shell supports a _basic_ run-or-raise workflow out of the box! In case this extension is broken or you cannot / don’t want to use it,
+
+1. Pin your favorite apps to the Dash (`Activities` → `Right click` on open app → `Pin to Dash`)
+2. Don’t let the default <kbd><Super+N></kbd> bindings cause you a left thumb [RSI](https://en.wikipedia.org/wiki/Repetitive_strain_injury)! To re-bind them, set dconf values `org.gnome.shell.keybindings` / `switch-to-application-N` to your desired keyboard shortcut (where N is 1..9), replacing / adding to the default binding.
+3. Never re-order your pinned apps!
+4. Enjoy a basic run-or-raise in Shell with no extension
+
+Caveats:
+
+- Limited to 9 apps! Choose wisely 😄.
+- No wmclass regex support; limited to static `StartupWMClass` in XDG `.desktop` files
+- No [run-or-raise "Modes"](#modes)
 
 # Installation
 


### PR DESCRIPTION
See https://github.com/CZ-NIC/run-or-raise/issues/68
and https://github.com/CZ-NIC/run-or-raise/issues/68#issuecomment-1850060281 .

---

@ maintainers: I did my best to be clear and concise.
Feel free to take or leave what you want and rephrase, no need to ask me.
Thanks for the extension!