### PR TITLE
Don't move pointer if it's already in the window area

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Switch back to the previous window when focused. If a shortcut has no but a sing
 #### `move-window-to-active-workspace`
 Move window to current workspace before focusing. If the window is on a different workspace, moves the window to the workspace you're currently viewing.
 #### `center-mouse-to-focused-window`
-After focus move mouse to window center
+Moves mouse to the center of the newly focused window (unless cursor is not in the window area already).
 #### `always-run`
 Both runs the command and raises a window
 ```

--- a/lib/action.js
+++ b/lib/action.js
@@ -2,6 +2,7 @@ import Shell from 'gi://Shell';
 import { Mode } from './mode.js';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
+import Mtk from 'gi://Mtk';
 
 class Action {
 
@@ -134,8 +135,15 @@ class Action {
         window.get_workspace().activate_with_focus(window, true)
         window.activate(0)
         if (this.mode.get(Mode.CENTER_MOUSE_TO_FOCUSED_WINDOW)) {
-            const { x, y, width, height } = window.get_frame_rect()
-            this.app.seat.warp_pointer(x + width / 2, y + height / 2)
+            let win_rect = window.get_frame_rect();
+            let [x, y] = global.get_pointer();
+            let pointer_rect = new Mtk.Rectangle({ x, y, width: 1, height: 1 });
+            if (pointer_rect.intersect(win_rect)[0]) {
+                return;
+            } else {
+                let { x, y, width, height } = win_rect;
+                this.app.seat.warp_pointer(x + width / 2, y + height / 2);
+            };
         }
         this.debug("Window activated")
         return true

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,5 @@
   ],
   "url": "https://github.com/CZ-NIC/run-or-raise",
   "uuid": "run-or-raise@edvard.cz",
-  "version": 33
+  "version": 34
 }


### PR DESCRIPTION
Avoid unnecessary mouse cursor jumps when there are multiple overlapping windows.

Credits:
- https://github.com/Dotrar/gnome-centre-focus
- https://github.com/LeonMatthes/mousefollowsfocus
- https://github.com/micheleg/dash-to-dock/pull/2091