### PR TITLE
Apply minimize-when-unfocused to raise modes

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -185,8 +185,13 @@ export class Action {
                 this.app.register[i] = this.get_windows()[0]
                 return
             }
-            if (mode.get(Mode.SWITCH_BACK_WHEN_FOCUSED) && registered.has_focus()) {
-                this._switch_back(registered, this.get_windows())
+            if (registered.has_focus()) {
+                if (mode.get(Mode.MINIMIZE_WHEN_UNFOCUSED)) {
+                    registered.minimize();
+                }
+                if (mode.get(Mode.SWITCH_BACK_WHEN_FOCUSED)) {
+                    this._switch_back(registered, this.get_windows())
+                }
                 return
             }
             if (!this.focus_window(registered, true)) {
@@ -199,8 +204,13 @@ export class Action {
         }
         if ((i = mode.get(Mode.RAISE))) {
             const registered = this.app.register[i]
-            if (mode.get(Mode.SWITCH_BACK_WHEN_FOCUSED) && registered && registered.has_focus()) {
-                this._switch_back(registered, this.get_windows())
+            if (registered && registered.has_focus()) {
+                if (mode.get(Mode.MINIMIZE_WHEN_UNFOCUSED)) {
+                    registered.minimize();
+                }
+                if (mode.get(Mode.SWITCH_BACK_WHEN_FOCUSED)) {
+                    this._switch_back(registered, this.get_windows())
+                }
                 return
             }
             return this.focus_window(registered, true)


### PR DESCRIPTION
## Summary

- Similar to https://github.com/CZ-NIC/run-or-raise/pull/94, this PR applies `minimize-when-unfocused` to raise modes.
- With both `minimize-when-unfocused` and `switch-back-when-focused` available in raise modes, users can register "quake" mode (raise-or-hide) on demand.

## Details

- The `minimize-when-unfocused` logic is now shared, so raise modes can minimize the registered window like the regular mode.

## Testing
- Reloaded GNOME Shell extension
- Verified `raise` with:
```
<Super>f q:raise(q):switch-back-when-focused:minimize-when-unfocused:move-window-to-active-workspace
<Super>f <Shift>q:register(q)
<Super>f a:raise(a):switch-back-when-focused:minimize-when-unfocused:move-window-to-active-workspace
<Super>f <Shift>a:register(a)
```

- Verified `raise-or-register` with:

```
<Super>f q:raise-or-register(q):switch-back-when-focused:minimize-when-unfocused:move-window-to-active-workspace
<Super>f <Shift>q:register(q)
<Super>f a:raise-or-register(a):switch-back-when-focused:minimize-when-unfocused:move-window-to-active-workspace
<Super>f <Shift>a:register(a)
```