### PR TITLE
fix: use Main.activateWindow() to properly dismiss Alt+Tab overlay

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -1,3 +1,4 @@
+import * as Main from 'resource:///org/gnome/shell/ui/main.js'
 import Shell from 'gi://Shell'
 import { Mode } from './mode.js'
 import Gio from 'gi://Gio'
@@ -134,8 +135,7 @@ export class Action {
             const activeWorkspace = global.workspaceManager.get_active_workspace();
             window.change_workspace(activeWorkspace);
         }
-        window.get_workspace().activate_with_focus(window, true)
-        window.activate(0)
+        Main.activateWindow(window)
         if (this.mode.get(Mode.CENTER_MOUSE_TO_FOCUSED_WINDOW)) {
             const win_rect = window.get_frame_rect()
             const [x, y] = global.get_pointer()


### PR DESCRIPTION
When a run-or-raise shortcut fires while the Alt+Tab switcher is visible, the switcher overlay gets stuck on screen. The root cause is that focus_window() was using low-level Mutter calls:

    window.get_workspace().activate_with_focus(window, true)
    window.activate(0)

These bypass GNOME Shell's WindowManager layer entirely. The Alt+Tab switcher tracks window focus through that layer and is never notified to dismiss itself, leaving the overlay in an inconsistent state.

Replace both calls with Main.activateWindow(window), the same function GNOME Shell's own Alt+Tab handler uses internally. It routes through the WindowManager layer and correctly tears down any active overlay before activating the target window.