### PR TITLE
 fix: remove `affectsInputRegion` from `addChrome()` for GNOME Shell 50 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+- fix: remove `affectsInputRegion` parameter from `addChrome()`, unsupported in GNOME Shell 50+
+
 ## 42 (2026-03-11)
 - Add parameter for the `switch-back-when-focused` mode that will cause the extension to switch back to a window regardless of what monitor it is on: `switch-back-when-focused(all_monitors)`
 

--- a/extension.js
+++ b/extension.js
@@ -255,7 +255,6 @@ class App {
             this.handler_layered.set_position(0, 0)
         }
         Main.layoutManager.addChrome(this.handler_layered, {
-            affectsInputRegion: true,
             trackFullscreen: true,
         })
         this.handler_layered.grab_key_focus()


### PR DESCRIPTION
### What

Removes the `affectsInputRegion: true` option from the `Main.layoutManager.addChrome()` call in `layered_mode_start()`.

### Why

GNOME Shell 50 removed `affectsInputRegion` as a valid parameter for `addChrome()`. Passing it now throws a hard error, which propagates up through `handler_accelerator_activated` and breaks layered shortcuts entirely. The error is visible in `journalctl --user`:

```
JS ERROR: Error: Run-or-raise> Error: Unrecognized parameter "affectsInputRegion"
    error@.../extension.js:44:15
    enable/this.handler_accelerator_activated<@.../extension.js:121:26
```

### How

`affectsInputRegion` was originally needed to ensure the invisible fullscreen overlay actor used during layered mode would intercept keystrokes at the compositor level rather than letting them pass through to the focused window. In GNOME Shell 50, this is no longer needed — the compositor automatically includes reactive actors in the input region. Since `handler_layered` is already created with `reactive: true` and `can_focus: true`, dropping the flag produces identical behavior on GNOME Shell 50 and does not affect older supported versions (45–49), where the parameter was accepted but similarly redundant given the actor's reactive state.

### Testing

Verified on GNOME Shell 50.0 / Fedora 44. Layered shortcuts activate correctly and the `affectsInputRegion` error no longer appears in the journal.

Fixed #101 